### PR TITLE
Modify merge logic to consider null values for equality in composite keys

### DIFF
--- a/intermine/integrate/src/main/java/org/intermine/dataloader/BatchingFetcher.java
+++ b/intermine/integrate/src/main/java/org/intermine/dataloader/BatchingFetcher.java
@@ -483,42 +483,44 @@ public class BatchingFetcher extends HintingFetcher {
             // }
             // }
 
-            // Constructing DB query
-            // "IN" check in SQL does not work with null values, so if a pk field can be
-            // null, We have to check for "IN values OR IS NULL"
-            for (String fieldName : pk.getFieldNames()) {
-                try {
-                    QueryField qf = new QueryField(qc, fieldName);
-                    if (nullableFieldNames.contains(fieldName)) {
-                        ConstraintSet csOr = new ConstraintSet(ConstraintOp.OR);
+            if (objCount > 0) {
+                // Constructing DB query
+                // "IN" check in SQL does not work with null values, so if a pk field can be
+                // null, We have to check for "IN values OR IS NULL"
+                for (String fieldName : pk.getFieldNames()) {
+                    try {
+                        QueryField qf = new QueryField(qc, fieldName);
+                        if (nullableFieldNames.contains(fieldName)) {
+                            ConstraintSet csOr = new ConstraintSet(ConstraintOp.OR);
 
-                        csOr.addConstraint(new SimpleConstraint(qf, ConstraintOp.IS_NULL));
-                        q.addToSelect(qf);
-                        csOr.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                            csOr.addConstraint(new SimpleConstraint(qf, ConstraintOp.IS_NULL));
+                            q.addToSelect(qf);
+                            csOr.addConstraint(
+                                    new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
 
-                        cs.addConstraint(csOr);
-                    } else {
-                        q.addToSelect(qf);
-                        cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
-                    }
-                } catch (IllegalArgumentException e) {
-                    QueryForeignKey qf = new QueryForeignKey(qc, fieldName);
-                    if (nullableFieldNames.contains(fieldName)) {
-                        ConstraintSet csOr = new ConstraintSet(ConstraintOp.OR);
+                            cs.addConstraint(csOr);
+                        } else {
+                            q.addToSelect(qf);
+                            cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                        }
+                    } catch (IllegalArgumentException e) {
+                        QueryForeignKey qf = new QueryForeignKey(qc, fieldName);
+                        if (nullableFieldNames.contains(fieldName)) {
+                            ConstraintSet csOr = new ConstraintSet(ConstraintOp.OR);
 
-                        csOr.addConstraint(new SimpleConstraint(qf, ConstraintOp.IS_NULL));
-                        q.addToSelect(qf);
-                        csOr.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                            csOr.addConstraint(new SimpleConstraint(qf, ConstraintOp.IS_NULL));
+                            q.addToSelect(qf);
+                            csOr.addConstraint(
+                                    new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
 
-                        cs.addConstraint(csOr);
-                    } else {
-                        q.addToSelect(qf);
-                        cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                            cs.addConstraint(csOr);
+                        } else {
+                            q.addToSelect(qf);
+                            cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                        }
                     }
                 }
-            }
 
-            if (objCount > 0) {
                 // Iterate through query, and add objects to results
                 // long time = System.currentTimeMillis();
                 int matches = 0;

--- a/intermine/integrate/src/main/java/org/intermine/dataloader/BatchingFetcher.java
+++ b/intermine/integrate/src/main/java/org/intermine/dataloader/BatchingFetcher.java
@@ -46,22 +46,23 @@ import org.intermine.objectstore.query.QueryField;
 import org.intermine.objectstore.query.QueryForeignKey;
 import org.intermine.objectstore.query.Results;
 import org.intermine.objectstore.query.ResultsRow;
+import org.intermine.objectstore.query.SimpleConstraint;
 import org.intermine.objectstore.query.SingletonResults;
 import org.intermine.util.CollectionUtil;
 import org.intermine.util.ShutdownHook;
 import org.intermine.util.Shutdownable;
 
 /**
- * Class providing EquivalentObjectFetcher functionality that batches fetches to improve
+ * Class providing EquivalentObjectFetcher functionality that batches fetches to
+ * improve
  * performance.
  *
  * @author Matthew Wakeling
  */
-public class BatchingFetcher extends HintingFetcher
-{
+public class BatchingFetcher extends HintingFetcher {
     private static final Logger LOG = Logger.getLogger(BatchingFetcher.class);
     protected Map<InterMineObject, Set<InterMineObject>> equivalents = Collections
-        .synchronizedMap(new WeakHashMap<InterMineObject, Set<InterMineObject>>());
+            .synchronizedMap(new WeakHashMap<InterMineObject, Set<InterMineObject>>());
     protected DataTracker dataTracker;
     protected Source source;
     protected int batchQueried = 0;
@@ -73,9 +74,9 @@ public class BatchingFetcher extends HintingFetcher
     /**
      * Constructor
      *
-     * @param fetcher another EquivalentObjectFetcher
+     * @param fetcher     another EquivalentObjectFetcher
      * @param dataTracker a DataTracker object to pass prefetch instructions to
-     * @param source the data Source that is being loaded
+     * @param source      the data Source that is being loaded
      */
     public BatchingFetcher(BaseEquivalentObjectFetcher fetcher, DataTracker dataTracker,
             Source source) {
@@ -85,7 +86,8 @@ public class BatchingFetcher extends HintingFetcher
     }
 
     /**
-     * Returns an ObjectStore layered on top of the given ObjectStore, which reports to this fetcher
+     * Returns an ObjectStore layered on top of the given ObjectStore, which reports
+     * to this fetcher
      * which objects are being loaded.
      *
      * @param os an ObjectStore
@@ -114,16 +116,16 @@ public class BatchingFetcher extends HintingFetcher
         if (source == this.source) {
             Set<InterMineObject> retval = equivalents.get(obj);
             if (retval != null) {
-                //Set expected = super.queryEquivalentObjects(obj, source);
-                //if (!retval.equals(expected)) {
-                //    throw new RuntimeException("BatchingFetcher produced incorrect result."
-                //            + " Expected " + expected + ", but got " + retval);
-                //}
+                // Set expected = super.queryEquivalentObjects(obj, source);
+                // if (!retval.equals(expected)) {
+                // throw new RuntimeException("BatchingFetcher produced incorrect result."
+                // + " Expected " + expected + ", but got " + retval);
+                // }
                 return retval;
             } else {
                 cacheMisses++;
                 retval = super.queryEquivalentObjects(obj, source);
-                //equivalents.put(obj, retval);
+                // equivalents.put(obj, retval);
                 return retval;
             }
         }
@@ -139,8 +141,10 @@ public class BatchingFetcher extends HintingFetcher
     protected void getEquivalentsFor(List<ResultsRow<Object>> batch) throws ObjectStoreException {
 
         List<FastPathObject> imos = new ArrayList<FastPathObject>();
-        // TODO: add all the objects that are referenced by these objects, and follow primary keys
-        // We can make use of the ObjectStoreFastCollectionsForTranslatorImpl's ability to work this
+        // TODO: add all the objects that are referenced by these objects, and follow
+        // primary keys
+        // We can make use of the ObjectStoreFastCollectionsForTranslatorImpl's ability
+        // to work this
         // all out for us.
         for (ResultsRow<Object> row : batch) {
             for (Object object : row) {
@@ -169,8 +173,10 @@ public class BatchingFetcher extends HintingFetcher
             savedDatabaseEmpty++;
             return;
         }
-        // TODO: add all the objects that are referenced by these objects, and follow primary keys
-        // We can make use of the ObjectStoreFastCollectionsForTranslatorImpl's ability to work this
+        // TODO: add all the objects that are referenced by these objects, and follow
+        // primary keys
+        // We can make use of the ObjectStoreFastCollectionsForTranslatorImpl's ability
+        // to work this
         // all out for us.
         Set<InterMineObject> objects = new HashSet<InterMineObject>();
         for (FastPathObject fpo : fpos) {
@@ -204,16 +210,13 @@ public class BatchingFetcher extends HintingFetcher
 
         objects.removeAll(equivalents.keySet());
         // Now objects contains all the objects we need to fetch data for.
-        Map<InterMineObject, Set<InterMineObject>> results = new HashMap<InterMineObject,
-            Set<InterMineObject>>();
+        Map<InterMineObject, Set<InterMineObject>> results = new HashMap<InterMineObject, Set<InterMineObject>>();
         for (InterMineObject object : objects) {
             results.put(object, Collections.synchronizedSet(new HashSet<InterMineObject>()));
         }
 
-        Map<PrimaryKey, ClassDescriptor> pksToDo
-            = new IdentityHashMap<PrimaryKey, ClassDescriptor>();
-        Map<ClassDescriptor, List<InterMineObject>> cldToObjectsForCld
-            = new IdentityHashMap<ClassDescriptor, List<InterMineObject>>();
+        Map<PrimaryKey, ClassDescriptor> pksToDo = new IdentityHashMap<PrimaryKey, ClassDescriptor>();
+        Map<ClassDescriptor, List<InterMineObject>> cldToObjectsForCld = new IdentityHashMap<ClassDescriptor, List<InterMineObject>>();
         Map<Class<?>, List<InterMineObject>> categorised = CollectionUtil.groupByClass(objects,
                 false);
         Map<ClassDescriptor, Boolean> cldsDone = new IdentityHashMap<ClassDescriptor, Boolean>();
@@ -237,10 +240,9 @@ public class BatchingFetcher extends HintingFetcher
                             savedTimes.put(className, new Long(System.currentTimeMillis() - time));
                         }
                         if (!classNotExists) {
-                            //LOG.error("Inspecting class " + className);
+                            // LOG.error("Inspecting class " + className);
                             List<InterMineObject> objectsForCld = new ArrayList<InterMineObject>();
-                            for (Map.Entry<Class<?>, List<InterMineObject>> category
-                                    : categorised.entrySet()) {
+                            for (Map.Entry<Class<?>, List<InterMineObject>> category : categorised.entrySet()) {
                                 if (cld.getType().isAssignableFrom(category.getKey())) {
                                     objectsForCld.addAll(category.getValue());
                                 }
@@ -248,11 +250,11 @@ public class BatchingFetcher extends HintingFetcher
                             cldToObjectsForCld.put(cld, objectsForCld);
                             // So now we have a list of objects for this CLD.
                             for (PrimaryKey pk : keysForClass) {
-                                //LOG.error("Adding pk " + cld.getName() + "." + pk.getName());
+                                // LOG.error("Adding pk " + cld.getName() + "." + pk.getName());
                                 pksToDo.put(pk, cld);
                             }
                         } else {
-                            //LOG.error("Empty class " + className);
+                            // LOG.error("Empty class " + className);
                         }
                     }
                 }
@@ -266,10 +268,11 @@ public class BatchingFetcher extends HintingFetcher
     /**
      * Fetches data for the given primary keys.
      *
-     * @param pksToDo a Map of the primary keys to fetch
-     * @param results a Map to hold results that are to be added to the cache
+     * @param pksToDo            a Map of the primary keys to fetch
+     * @param results            a Map to hold results that are to be added to the
+     *                           cache
      * @param cldToObjectsForCld a Map of Lists of objects relevant to PrimaryKeys
-     * @param time1 the time that processing started
+     * @param time1              the time that processing started
      * @throws ObjectStoreException if something goes wrong
      */
     protected void doPks(Map<PrimaryKey, ClassDescriptor> pksToDo,
@@ -277,8 +280,7 @@ public class BatchingFetcher extends HintingFetcher
             Map<ClassDescriptor, List<InterMineObject>> cldToObjectsForCld,
             long time1) throws ObjectStoreException {
         Set<Integer> fetchedObjectIds = Collections.synchronizedSet(new HashSet<Integer>());
-        Map<PrimaryKey, ClassDescriptor> pksNotDone
-            = new IdentityHashMap<PrimaryKey, ClassDescriptor>(pksToDo);
+        Map<PrimaryKey, ClassDescriptor> pksNotDone = new IdentityHashMap<PrimaryKey, ClassDescriptor>(pksToDo);
         while (!pksToDo.isEmpty()) {
             int startPksToDoSize = pksToDo.size();
             Iterator<PrimaryKey> pkIter = pksToDo.keySet().iterator();
@@ -286,13 +288,13 @@ public class BatchingFetcher extends HintingFetcher
                 PrimaryKey pk = pkIter.next();
                 ClassDescriptor cld = pksToDo.get(pk);
                 if (canDoPkNow(pk, cld, pksNotDone)) {
-                    //LOG.error("Running pk " + cld.getName() + "." + pk.getName());
+                    // LOG.error("Running pk " + cld.getName() + "." + pk.getName());
                     doPk(pk, cld, results, cldToObjectsForCld.get(cld),
                             fetchedObjectIds);
                     pkIter.remove();
                     pksNotDone.remove(pk);
                 } else {
-                    //LOG.error("Cannot do pk " + cld.getName() + "." + pk.getName() + " yet");
+                    // LOG.error("Cannot do pk " + cld.getName() + "." + pk.getName() + " yet");
                 }
             }
             if (pksToDo.size() == startPksToDoSize) {
@@ -309,8 +311,8 @@ public class BatchingFetcher extends HintingFetcher
     /**
      * Returns whether this primary key can be fetched now.
      *
-     * @param pk the PrimaryKey
-     * @param cld the ClassDescriptor that the PrimaryKey is in
+     * @param pk         the PrimaryKey
+     * @param cld        the ClassDescriptor that the PrimaryKey is in
      * @param pksNotDone a Map of pks not yet fetched
      * @return a boolean
      */
@@ -326,7 +328,7 @@ public class BatchingFetcher extends HintingFetcher
                 while (otherCldIter.hasNext() && canDoPkNow) {
                     ClassDescriptor otherCld = otherCldIter.next();
                     Class<? extends FastPathObject> fieldClass = ((ReferenceDescriptor) fd)
-                        .getReferencedClassDescriptor().getType();
+                            .getReferencedClassDescriptor().getType();
                     if (otherCld.getType().isAssignableFrom(fieldClass)
                             || fieldClass.isAssignableFrom(otherCld.getType())) {
                         canDoPkNow = false;
@@ -340,16 +342,18 @@ public class BatchingFetcher extends HintingFetcher
     /**
      * Fetches equivalent objects for a particular primary key.
      *
-     * @param pk the PrimaryKey
-     * @param cld the ClassDescriptor of the PrimaryKey
-     * @param results a Map to hold results that are to be added to the cache
-     * @param objectsForCld a List of objects relevant to this PrimaryKey
-     * @param fetchedObjectIds a Set to hold ids of objects that are fetched, to prefetch from the
-     * data tracker later
+     * @param pk               the PrimaryKey
+     * @param cld              the ClassDescriptor of the PrimaryKey
+     * @param results          a Map to hold results that are to be added to the
+     *                         cache
+     * @param objectsForCld    a List of objects relevant to this PrimaryKey
+     * @param fetchedObjectIds a Set to hold ids of objects that are fetched, to
+     *                         prefetch from the
+     *                         data tracker later
      * @throws ObjectStoreException if something goes wrong
      */
-    protected void doPk(PrimaryKey pk, ClassDescriptor cld, Map<InterMineObject,
-            Set<InterMineObject>> results, List<InterMineObject> objectsForCld,
+    protected void doPk(PrimaryKey pk, ClassDescriptor cld, Map<InterMineObject, Set<InterMineObject>> results,
+            List<InterMineObject> objectsForCld,
             Set<Integer> fetchedObjectIds) throws ObjectStoreException {
         Iterator<InterMineObject> objectsForCldIter = objectsForCld.iterator();
         while (objectsForCldIter.hasNext()) {
@@ -362,30 +366,33 @@ public class BatchingFetcher extends HintingFetcher
             ConstraintSet cs = new ConstraintSet(ConstraintOp.AND);
             q.setConstraint(cs);
             Map<String, Set<Object>> fieldNameToValues = new HashMap<String, Set<Object>>();
+            // Fields where null is a value (cannot add it in fieldNameToValues, see further
+            // down below)
+            Set<String> nullableFieldNames = new HashSet<String>();
+
             for (String fieldName : pk.getFieldNames()) {
                 try {
-                    QueryField qf = new QueryField(qc, fieldName);
-                    q.addToSelect(qf);
+                    // QueryField qf = new QueryField(qc, fieldName);
+                    // q.addToSelect(qf);
                     Set<Object> values = new HashSet<Object>();
                     fieldNameToValues.put(fieldName, values);
-                    cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, values));
+                    // cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, values));
                 } catch (IllegalArgumentException e) {
-                    QueryForeignKey qf = new QueryForeignKey(qc, fieldName);
-                    q.addToSelect(qf);
+                    // QueryForeignKey qf = new QueryForeignKey(qc, fieldName);
+                    // q.addToSelect(qf);
                     Set<Object> values = new HashSet<Object>();
                     fieldNameToValues.put(fieldName, values);
-                    cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, values));
+                    // cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, values));
                 }
             }
+
             // Now make a map from the primary key values to source objects
-            Map<List<Object>, InterMineObject> keysToSourceObjects =
-                new HashMap<List<Object>, InterMineObject>();
+            Map<List<Object>, InterMineObject> keysToSourceObjects = new HashMap<List<Object>, InterMineObject>();
             while (objectsForCldIter.hasNext() && (objCount < 500)) {
                 InterMineObject object = objectsForCldIter.next();
                 origObjCount++;
                 try {
-                    if (DataLoaderHelper.objectPrimaryKeyNotNull(model, object, cld, pk, source,
-                                idMap)) {
+                    if (DataLoaderHelper.objectPrimaryKeyNotNull(model, object, cld, pk, source, idMap)) {
                         List<Collection<Object>> values = new ArrayList<Collection<Object>>();
                         boolean skipObject = false;
                         Map<String, Set<Object>> fieldsValues = new HashMap<String, Set<Object>>();
@@ -422,7 +429,7 @@ public class BatchingFetcher extends HintingFetcher
                                             .getType()) + "." + fieldName;
                                     if (!savedTimes.containsKey(summaryName)) {
                                         savedTimes.put(summaryName, new Long(System
-                                                    .currentTimeMillis() - time));
+                                                .currentTimeMillis() - time));
                                         savedCounts.put(summaryName, new Integer(0));
                                     }
                                     if (pkQueryFruitless) {
@@ -436,8 +443,13 @@ public class BatchingFetcher extends HintingFetcher
                         if (!skipObject) {
                             objCount++;
                             for (String fieldName : pk.getFieldNames()) {
-                                fieldNameToValues.get(fieldName).addAll(fieldsValues
-                                        .get(fieldName));
+                                for (Object fv : fieldsValues.get(fieldName)) {
+                                    if (fv != null) {
+                                        fieldNameToValues.get(fieldName).add(fv);
+                                    } else {
+                                        nullableFieldNames.add(fieldName);
+                                    }
+                                }
                             }
                             for (List<Object> valueSet : CollectionUtil
                                     .fanOutCombinations(values)) {
@@ -453,28 +465,66 @@ public class BatchingFetcher extends HintingFetcher
                     throw new ObjectStoreException(e);
                 }
             }
+
             // Prune BagConstraints using the hints system.
-            //boolean emptyQuery = false;
-            //Iterator<String> fieldNameIter = pk.getFieldNames().iterator();
-            //while (fieldNameIter.hasNext() && (!emptyQuery)) {
-            //    String fieldName = fieldNameIter.next();
-            //    Set values = fieldNameToValues.get(fieldName);
-                //Iterator valueIter = values.iterator();
-                //while (valueIter.hasNext()) {
-                //    if (hints.pkQueryFruitless(cld.getType(), fieldName, valueIter.next())) {
-                //        valueIter.remove();
-                //    }
-                //}
-            //    if (values.isEmpty()) {
-            //        emptyQuery = true;
-            //    }
-            //}
+            // boolean emptyQuery = false;
+            // Iterator<String> fieldNameIter = pk.getFieldNames().iterator();
+            // while (fieldNameIter.hasNext() && (!emptyQuery)) {
+            // String fieldName = fieldNameIter.next();
+            // Set values = fieldNameToValues.get(fieldName);
+            // Iterator valueIter = values.iterator();
+            // while (valueIter.hasNext()) {
+            // if (hints.pkQueryFruitless(cld.getType(), fieldName, valueIter.next())) {
+            // valueIter.remove();
+            // }
+            // }
+            // if (values.isEmpty()) {
+            // emptyQuery = true;
+            // }
+            // }
+
+            // Constructing DB query
+            // "IN" check in SQL does not work with null values, so if a pk field can be
+            // null, We have to check for "IN values OR IS NULL"
+            for (String fieldName : pk.getFieldNames()) {
+                try {
+                    QueryField qf = new QueryField(qc, fieldName);
+                    if (nullableFieldNames.contains(fieldName)) {
+                        ConstraintSet csOr = new ConstraintSet(ConstraintOp.OR);
+
+                        csOr.addConstraint(new SimpleConstraint(qf, ConstraintOp.IS_NULL));
+                        q.addToSelect(qf);
+                        csOr.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+
+                        cs.addConstraint(csOr);
+                    } else {
+                        q.addToSelect(qf);
+                        cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                    }
+                } catch (IllegalArgumentException e) {
+                    QueryForeignKey qf = new QueryForeignKey(qc, fieldName);
+                    if (nullableFieldNames.contains(fieldName)) {
+                        ConstraintSet csOr = new ConstraintSet(ConstraintOp.OR);
+
+                        csOr.addConstraint(new SimpleConstraint(qf, ConstraintOp.IS_NULL));
+                        q.addToSelect(qf);
+                        csOr.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+
+                        cs.addConstraint(csOr);
+                    } else {
+                        q.addToSelect(qf);
+                        cs.addConstraint(new BagConstraint(qf, ConstraintOp.IN, fieldNameToValues.get(fieldName)));
+                    }
+                }
+            }
+
             if (objCount > 0) {
                 // Iterate through query, and add objects to results
-                //long time = System.currentTimeMillis();
+                // long time = System.currentTimeMillis();
                 int matches = 0;
                 Results res = lookupOs.execute(q, 2000, false, false, false);
-                @SuppressWarnings("unchecked") List<ResultsRow<Object>> tmpRes = (List) res;
+                @SuppressWarnings("unchecked")
+                List<ResultsRow<Object>> tmpRes = (List) res;
                 for (ResultsRow<Object> row : tmpRes) {
                     List<Object> values = new ArrayList<Object>();
                     for (int i = 1; i <= pk.getFieldNames().size(); i++) {
@@ -487,15 +537,14 @@ public class BatchingFetcher extends HintingFetcher
                     }
                     fetchedObjectIds.add(((InterMineObject) row.get(0)).getId());
                 }
-                //LOG.info("Fetched " + res.size() + " equivalent objects for " + objCount
-                //        + " objects in " + (System.currentTimeMillis() - time) + " ms for "
-                //        + cld.getName() + "." + pk.getName());
+                // LOG.info("Fetched " + res.size() + " equivalent objects for " + objCount
+                // + " objects in " + (System.currentTimeMillis() - time) + " ms for "
+                // + cld.getName() + "." + pk.getName());
             }
         }
     }
 
-    private class NoseyObjectStore extends ObjectStorePassthruImpl implements Shutdownable
-    {
+    private class NoseyObjectStore extends ObjectStorePassthruImpl implements Shutdownable {
         public NoseyObjectStore(ObjectStore os) {
             super(os);
             ShutdownHook.registerObject(this);
@@ -585,4 +634,3 @@ public class BatchingFetcher extends HintingFetcher
         }
     }
 }
-

--- a/intermine/integrate/src/main/java/org/intermine/dataloader/DataLoaderHelper.java
+++ b/intermine/integrate/src/main/java/org/intermine/dataloader/DataLoaderHelper.java
@@ -44,27 +44,27 @@ import org.intermine.metadata.StringUtil;
 import org.intermine.metadata.TypeUtil;
 
 /**
- * Class providing utility methods to help with primary key and data source priority configuration
+ * Class providing utility methods to help with primary key and data source
+ * priority configuration
  *
  * @author Andrew Varley
  * @author Mark Woodbridge
  * @author Richard Smith
  * @author Matthew Wakeling
  */
-public final class DataLoaderHelper
-{
+public final class DataLoaderHelper {
     private DataLoaderHelper() {
     }
 
     private static final Logger LOG = Logger.getLogger(DataLoaderHelper.class);
 
     protected static Map<Source, Properties> sourceKeys = new HashMap<Source, Properties>();
-    protected static Map<Model, Map<String, List<String>>> modelDescriptors
-        = new IdentityHashMap<Model, Map<String, List<String>>>();
+    protected static Map<Model, Map<String, List<String>>> modelDescriptors = new IdentityHashMap<Model, Map<String, List<String>>>();
     protected static Set<Source> verifiedSources = new HashSet<Source>();
 
     /**
-     * Build a map from class and field names to a priority-ordered List of source name Strings.
+     * Build a map from class and field names to a priority-ordered List of source
+     * name Strings.
      *
      * @param model the Model
      * @return the Map
@@ -76,7 +76,7 @@ public final class DataLoaderHelper
             if (descriptorSources == null) {
                 descriptorSources = new HashMap<String, List<String>>();
                 Properties priorities = PropertiesUtil.loadProperties(model.getName()
-                                                                      + "_priorities.properties");
+                        + "_priorities.properties");
                 if (priorities == null) {
                     throw new RuntimeException("Could not load priorities config file "
                             + model.getName() + "_priorities.properties");
@@ -102,19 +102,23 @@ public final class DataLoaderHelper
         return descriptorSources;
     }
 
-    private static Map<GetPrimaryKeyCacheKey, Set<PrimaryKey>> getPrimaryKeyCache
-        = new HashMap<GetPrimaryKeyCacheKey, Set<PrimaryKey>>();
+    private static Map<GetPrimaryKeyCacheKey, Set<PrimaryKey>> getPrimaryKeyCache = new HashMap<GetPrimaryKeyCacheKey, Set<PrimaryKey>>();
 
     /**
-     * Return a Set of PrimaryKeys relevant to a given Source for a ClassDescriptor. The Set
-     * contains all the primary keys that exist on a particular class that are used by the
-     * source, without performing any recursion. The Model.getClassDescriptorsForClass()
-     * method is recommended if you wish for all the primary keys of the class' parents
+     * Return a Set of PrimaryKeys relevant to a given Source for a ClassDescriptor.
+     * The Set
+     * contains all the primary keys that exist on a particular class that are used
+     * by the
+     * source, without performing any recursion. The
+     * Model.getClassDescriptorsForClass()
+     * method is recommended if you wish for all the primary keys of the class'
+     * parents
      * as well.
      *
-     * @param cld the ClassDescriptor
+     * @param cld    the ClassDescriptor
      * @param source the Source
-     * @param os the ObjectStore that these PrimaryKeys are used in, for creating indexes
+     * @param os     the ObjectStore that these PrimaryKeys are used in, for
+     *               creating indexes
      * @return a Set of PrimaryKeys
      */
     public static Set<PrimaryKey> getPrimaryKeys(ClassDescriptor cld, Source source,
@@ -137,9 +141,9 @@ public final class DataLoaderHelper
                             if (!cldName.contains(".")) {
                                 ClassDescriptor iCld = cld.getModel().getClassDescriptorByName(
                                         packageNameWithDot + cldName);
-                                if  (iCld != null) {
+                                if (iCld != null) {
                                     Map<String, PrimaryKey> map = PrimaryKeyUtil
-                                        .getPrimaryKeys(iCld);
+                                            .getPrimaryKeys(iCld);
 
                                     String[] tokens = keyList.split(",");
                                     for (int i = 0; i < tokens.length; i++) {
@@ -193,16 +197,14 @@ public final class DataLoaderHelper
                                 if (!keySet.contains(pk)) {
                                     keySet.add(pk);
                                     if (os instanceof ObjectStoreInterMineImpl) {
-                                        ObjectStoreInterMineImpl osimi
-                                            = (ObjectStoreInterMineImpl) os;
+                                        ObjectStoreInterMineImpl osimi = (ObjectStoreInterMineImpl) os;
                                         DatabaseSchema schema = osimi.getSchema();
                                         ClassDescriptor tableMaster = schema.getTableMaster(cld);
                                         String tableName = DatabaseUtil.getTableName(tableMaster);
                                         List<String> fields = new ArrayList<String>();
 
                                         for (String field : pk.getFieldNames()) {
-                                            String colName =
-                                                DatabaseUtil.generateSqlCompatibleName(field);
+                                            String colName = DatabaseUtil.generateSqlCompatibleName(field);
                                             if (tableMaster.getReferenceDescriptorByName(field,
                                                     true) != null) {
                                                 colName += "id";
@@ -210,9 +212,10 @@ public final class DataLoaderHelper
                                             fields.add(colName);
                                         }
                                         String sql = "CREATE INDEX " + tableName + "__" + keyName
-                                            + " ON " + tableName + " (" + StringUtil.join(fields,
-                                                        ", ") + ")";
-                                        System.out .println("Creating index: " + sql);
+                                                + " ON " + tableName + " (" + StringUtil.join(fields,
+                                                        ", ")
+                                                + ")";
+                                        System.out.println("Creating index: " + sql);
                                         LOG.info("Creating index: " + sql);
                                         Connection conn = null;
                                         try {
@@ -241,13 +244,15 @@ public final class DataLoaderHelper
         }
     }
 
-
     /**
-     * Fetch all primary keys for the given source. Parses source keys properties file, can handle
-     * both 'old style' key definitions (key name used in source, details found in keyDefs file)
+     * Fetch all primary keys for the given source. Parses source keys properties
+     * file, can handle
+     * both 'old style' key definitions (key name used in source, details found in
+     * keyDefs file)
      * and 'new style' where whole key is defined in the source properties file.
+     * 
      * @param source name of source to fetch keys for
-     * @param model the data model
+     * @param model  the data model
      * @return a set of primary key objects
      */
     public static Set<PrimaryKey> getSourcePrimaryKeys(Source source, Model model) {
@@ -333,8 +338,8 @@ public final class DataLoaderHelper
 
                 if (keys == null) {
                     throw new RuntimeException("can't find keys for source: " + source
-                                               + " after trying to find: " + sourceNameKeysFileName
-                                               + " and: " + sourceTypeKeysFileName);
+                            + " after trying to find: " + sourceNameKeysFileName
+                            + " and: " + sourceTypeKeysFileName);
                 }
 
                 sourceKeys.put(source, keys);
@@ -343,25 +348,27 @@ public final class DataLoaderHelper
         return keys;
     }
 
-
     /**
-     * Look a the values of the given primary key in the object and return true if and only if some
-     * part of the primary key is null.  If the primary key contains a reference it is sufficient
-     * for any of the primary keys of the referenced object to be non-null (ie
-     * objectPrimaryKeyIsNull() returning true).
-     * @param model the Model in which to find ClassDescriptors
-     * @param obj the Object to check
-     * @param cld one of the classes that obj is.  Only primary keys for this classes will be
-     * checked
-     * @param pk the primary key to check
+     * Returns true if any of the values of the given primary key is not null.
+     * Otherwise (all values of the given primary key are null), returns false.
+     * If the primary key contains a reference, it is sufficient to consider
+     * the primary key not null.
+     * 
+     * @param model  the Model in which to find ClassDescriptors
+     * @param obj    the Object to check
+     * @param cld    one of the classes that obj is. Only primary keys for this
+     *               classes will be
+     *               checked
+     * @param pk     the primary key to check
      * @param source the Source database
-     * @param idMap an IntToIntMap from source IDs to destination IDs
+     * @param idMap  an IntToIntMap from source IDs to destination IDs
      * @return true if the the given primary key is non-null for the given object
      * @throws MetaDataException if anything goes wrong
      */
     public static boolean objectPrimaryKeyNotNull(Model model, InterMineObject obj,
             ClassDescriptor cld, PrimaryKey pk, Source source,
             IntToIntMap idMap) throws MetaDataException {
+
         for (String fieldName : pk.getFieldNames()) {
             FieldDescriptor fd = cld.getFieldDescriptorByName(fieldName);
             if (fd instanceof AttributeDescriptor) {
@@ -372,8 +379,9 @@ public final class DataLoaderHelper
                     throw new MetaDataException("Failed to get field " + fieldName
                             + " for key " + pk + " from " + obj, e);
                 }
-                if (value == null) {
-                    return false;
+
+                if (value != null) {
+                    return true;
                 }
             } else if (fd instanceof CollectionDescriptor) {
                 throw new MetaDataException("Primary key " + pk.getName() + " for class "
@@ -387,71 +395,33 @@ public final class DataLoaderHelper
                 } catch (IllegalAccessException e) {
                     throw new MetaDataException("Failed to get field " + fieldName
                             + " for key " + pk + " from " + obj, e);
-
-                }
-                if (refObj == null) {
-                    return false;
                 }
 
-                if ((refObj.getId() != null) && (idMap.get(refObj.getId()) != null)) {
-                    // We have previously loaded the object in this reference.
-                    continue;
-                }
-
-                if (refObj instanceof ProxyReference) {
-                    refObj = ((ProxyReference) refObj).getObject();
-                }
-
-                boolean foundNonNullKey = false;
-                boolean foundKey = false;
-                Set<ClassDescriptor> classDescriptors = model.getClassDescriptorsForClass(refObj
-                        .getClass());
-
-            CLDS:
-                for (ClassDescriptor refCld : classDescriptors) {
-                    Set<PrimaryKey> primaryKeys;
-
-                    if (source == null) {
-                        primaryKeys = new LinkedHashSet<PrimaryKey>(PrimaryKeyUtil
-                                .getPrimaryKeys(refCld).values());
-                    } else {
-                        primaryKeys = DataLoaderHelper.getPrimaryKeys(refCld, source, null);
-                    }
-
-                    for (PrimaryKey refPK : primaryKeys) {
-                        foundKey = true;
-
-                        if (objectPrimaryKeyNotNull(model, refObj, refCld, refPK, source, idMap)) {
-                            foundNonNullKey = true;
-                            break CLDS;
-                        }
-                    }
-                }
-
-                if (foundKey && (!foundNonNullKey)) {
-                    return false;
+                if (refObj != null) {
+                    return true;
                 }
             }
         }
 
-        return true;
+        return false;
     }
 
-    private static ThreadLocal<Map<PrimaryKeyCacheKey, Set<String>>> primaryKeyCache
-        = new ThreadLocal<Map<PrimaryKeyCacheKey, Set<String>>>() {
-            @Override protected Map<PrimaryKeyCacheKey, Set<String>> initialValue() {
-                return new HashMap<PrimaryKeyCacheKey, Set<String>>();
-            }
-        };
+    private static ThreadLocal<Map<PrimaryKeyCacheKey, Set<String>>> primaryKeyCache = new ThreadLocal<Map<PrimaryKeyCacheKey, Set<String>>>() {
+        @Override
+        protected Map<PrimaryKeyCacheKey, Set<String>> initialValue() {
+            return new HashMap<PrimaryKeyCacheKey, Set<String>>();
+        }
+    };
 
     /**
-     * Returns true if the given field is a member of any primary key on the given class, for the
+     * Returns true if the given field is a member of any primary key on the given
+     * class, for the
      * given source.
      *
-     * @param model the Model in which to find ClassDescriptors
-     * @param clazz the Class in which to look
+     * @param model     the Model in which to find ClassDescriptors
+     * @param clazz     the Class in which to look
      * @param fieldName the name of the field to check
-     * @param source the Source that the keys belong to
+     * @param source    the Source that the keys belong to
      * @return true if the field is a primary key
      */
     public static boolean fieldIsPrimaryKey(Model model, Class<?> clazz, String fieldName,
@@ -471,8 +441,7 @@ public final class DataLoaderHelper
         return fields.contains(fieldName);
     }
 
-    private static class PrimaryKeyCacheKey
-    {
+    private static class PrimaryKeyCacheKey {
         private Model model;
         private Class<?> clazz;
         private Source source;
@@ -493,14 +462,13 @@ public final class DataLoaderHelper
             if (o instanceof PrimaryKeyCacheKey) {
                 PrimaryKeyCacheKey pkck = (PrimaryKeyCacheKey) o;
                 return (model == pkck.model) && clazz.equals(pkck.clazz)
-                    && source.equals(pkck.source);
+                        && source.equals(pkck.source);
             }
             return false;
         }
     }
 
-    private static class GetPrimaryKeyCacheKey
-    {
+    private static class GetPrimaryKeyCacheKey {
         private ClassDescriptor cld;
         private Source source;
 

--- a/intermine/integrate/src/main/java/org/intermine/dataloader/EquivalentObjectHints.java
+++ b/intermine/integrate/src/main/java/org/intermine/dataloader/EquivalentObjectHints.java
@@ -37,22 +37,20 @@ import org.intermine.util.AlwaysSet;
 import org.intermine.util.PseudoSet;
 
 /**
- * Object for holding hint data for the getEquivalentObjects method in IntegrationWriters.
+ * Object for holding hint data for the getEquivalentObjects method in
+ * IntegrationWriters.
  *
  * @author Matthew Wakeling
  */
-public class EquivalentObjectHints
-{
+public class EquivalentObjectHints {
     private static final Logger LOG = Logger.getLogger(EquivalentObjectHints.class);
     private static final int SUMMARY_SIZE = 100;
 
     private boolean databaseEmptyChecked = false;
     private boolean databaseEmpty = false;
     private Map<Class<?>, Boolean> classStatus = new HashMap<Class<?>, Boolean>();
-    private Map<ClassAndFieldName, Set<Object>> classAndFieldNameValues
-        = new HashMap<ClassAndFieldName, Set<Object>>();
-    private Map<ClassAndFieldName, Set<Object>> classAndFieldNameQueried
-        = new HashMap<ClassAndFieldName, Set<Object>>();
+    private Map<ClassAndFieldName, Set<Object>> classAndFieldNameValues = new HashMap<ClassAndFieldName, Set<Object>>();
+    private Map<ClassAndFieldName, Set<Object>> classAndFieldNameQueried = new HashMap<ClassAndFieldName, Set<Object>>();
     private Map<String, ClassAndFieldName> summaryToCafn = new HashMap<String, ClassAndFieldName>();
 
     private ObjectStore os;
@@ -134,12 +132,13 @@ public class EquivalentObjectHints
     }
 
     /**
-     * Returns true if there were no instances of the given class with the given field set to the
+     * Returns true if there were no instances of the given class with the given
+     * field set to the
      * given value.
      *
-     * @param clazz the class, must be in the model
+     * @param clazz     the class, must be in the model
      * @param fieldName the name of the field
-     * @param value the value
+     * @param value     the value
      * @return a boolean
      */
     public boolean pkQueryFruitless(Class<? extends FastPathObject> clazz, String fieldName,
@@ -222,11 +221,13 @@ public class EquivalentObjectHints
         } else if (queried instanceof IntegerRangeSet) {
             queried.add(value);
         }
+
         return !values.contains(value);
     }
 
     /**
-     * Returns a Set of values that have been tested for a particular class and fieldname.
+     * Returns a Set of values that have been tested for a particular class and
+     * fieldname.
      *
      * @param summaryName a String
      * @return a Set of values, or an AlwaysSet if too many values were tested
@@ -236,7 +237,8 @@ public class EquivalentObjectHints
     }
 
     /**
-     * Returns a Set of values that were in the database for a particular class and fieldname.
+     * Returns a Set of values that were in the database for a particular class and
+     * fieldname.
      *
      * @param summaryName a String
      * @return a Set of values, or an AlwaysSet if too many values were tested
@@ -245,8 +247,7 @@ public class EquivalentObjectHints
         return classAndFieldNameValues.get(summaryToCafn.get(summaryName));
     }
 
-    private static class ClassAndFieldName
-    {
+    private static class ClassAndFieldName {
         private Class<? extends FastPathObject> clazz;
         private String fieldName;
 
@@ -270,8 +271,7 @@ public class EquivalentObjectHints
         }
     }
 
-    private static class IntegerRangeSet extends PseudoSet<Object>
-    {
+    private static class IntegerRangeSet extends PseudoSet<Object> {
         private int low, high;
 
         public IntegerRangeSet() {
@@ -285,15 +285,20 @@ public class EquivalentObjectHints
         }
 
         public boolean contains(Object o) {
+            if (o == null) { // IntegerRangeSet cannot contain/check for null
+                return false;
+            }
             int i = ((Integer) o).intValue();
             return (i >= low) && (i <= high);
         }
 
         @Override
         public boolean add(Object o) {
-            int i = ((Integer) o).intValue();
-            low = Math.min(low, i);
-            high = Math.max(high, i);
+            if (o != null) { // Cannot add null in IntegerRangeSet
+                int i = ((Integer) o).intValue();
+                low = Math.min(low, i);
+                high = Math.max(high, i);
+            }
             return false;
         }
 


### PR DESCRIPTION
Modify merge logic to consider null values for equality in composite keys (where at least one value of the key is not null), this does not apply to single-field keys with a null value. Logic was changed in `BatchingFetcher`, which is the subclass of `BaseEquivalentObjectFetcher` that seems to be used in Intermine (or its `ParallelBatchingFetcher` subclass, if another class is used it will probably give errors.

Explanation of the changes per file:

`BatchingFetcher.java`
- In `doPk()` (used in `BatchingFetcher` and `ParallelBatchingFetcher`), which is used to fetch equivalent for a primary key, move query construction to before executing the query, and after collecting pk field values.
- When collecting PK values, adding null values (or rather field names) in a separate set than the `fieldNameToValues` map
- This is necessary because the query checks for each object in the DB if values for each pk fields is in the list of collected values, however `IN` in SQL does not work with NULL values, so we have to change the query to "if pk field value in collected values or is null".
- The IS NULL check is only added if a null value was found in the collected values for each pk field

`DataLoaderHelper.java`
- In `objectPrimaryKeyNotNull()` (used in `BaseEquivalentObjectFetcher` and `BatchingFetcher`, which returns true if the given primary key is not null, modify the "is not null" definition from "all values of the PK must be not null" to "has at least one non-null value".
- For reference fields, the method used to check the primary keys of the referenced object, and if any of its primary keys was not null, the referenced object was considered not null. I have removed this part entirely, and it now only checks if there is a reference to an object to be considered not null, but I need confirmation that it is an acceptable logic or not @sergiocontrino 
- If this method return false (=pk is null), the object is not considered for merging (if I understood correctly)

`EquivalentObjectHints.java`
- In `pkQueryFruitless()` (used in `HintingFetcher` and `BatchingFetcher`), which, if I understood correctly, is used to check (in cache when possible) if there is no match in DB for a specific value of a specific class' field (or if it's guaranteed to have no match?), ignore null values for int fields, which have a specific class for optimisation called `IntegerRangeSet` (which cannot handle null values)

Tested with MDRMine all sources, subsets for CTG and WHO.